### PR TITLE
Improve ByteArray read methods

### DIFF
--- a/libs/bArray.lua
+++ b/libs/bArray.lua
@@ -13,8 +13,8 @@ local table_setNewClass = table.setNewClass
 local table_writeBytes = table.writeBytes
 ------------------
 
-local modulo256 = function(n)
-	return n % 256
+local band255 = function(n)
+	return bit_band(n, 255)
 end
 
 ------------------
@@ -52,7 +52,7 @@ byteArray.write8 = function(self, ...)
 		tbl = { 0 }
 	end
 
-	local bytes = table_mapArray(tbl, modulo256)
+	local bytes = table_mapArray(tbl, band255)
 	table_add(self.stack, bytes)
 	return self
 end
@@ -65,8 +65,8 @@ end
 byteArray.write16 = function(self, short)
 	-- (long >> 8) & 0xFF, long & 0xFF
 	return self:write8(
-		bit_band(bit_rshift(short, 8), 0xFF),
-		bit_band(short, 0xFF)
+		bit_rshift(short, 8),
+		short
 	)
 end
 --[[@
@@ -78,9 +78,9 @@ end
 byteArray.write24 = function(self, int)
 	-- (long >> 16) & 0xFF, (long >> 8) & 0xFF, long & 0xFF
 	return self:write8(
-		bit_band(bit_rshift(int, 16), 0xFF),
-		bit_band(bit_rshift(int, 8), 0xFF),
-		bit_band(int, 0xFF)
+		bit_rshift(int, 16),
+		bit_rshift(int, 8),
+		int
 	)
 end
 --[[@
@@ -92,10 +92,10 @@ end
 byteArray.write32 = function(self, long)
 	-- (long >> 24) & 0xFF, (long >> 16) & 0xFF, (long >> 8) & 0xFF, long & 0xFF
 	return self:write8(
-		bit_band(bit_rshift(long, 24), 0xFF),
-		bit_band(bit_rshift(long, 16), 0xFF),
-		bit_band(bit_rshift(long, 8), 0xFF),
-		bit_band(long, 0xFF)
+		bit_rshift(long, 24),
+		bit_rshift(long, 16),
+		bit_rshift(long, 8),
+		long
 	)
 end
 --[[@

--- a/libs/bArray.lua
+++ b/libs/bArray.lua
@@ -41,6 +41,14 @@ byteArray.new = function(self, stack)
 	}, self)
 end
 --[[@
+	@name bytesLeft
+	@desc Returns the number of bytes left in the stack.
+	@returns int Number of bytes left in the stack.
+]]
+byteArray.bytesLeft = function(self)
+	return #self.stack - self.pos + 1
+end
+--[[@
 	@name write8
 	@desc Inserts bytes in the byte array.
 	@param ...?<int> Bytes. @default 0

--- a/libs/bArray.lua
+++ b/libs/bArray.lua
@@ -21,23 +21,21 @@ end
 
 local byteArray = table.setNewClass()
 byteArray.__tostring = function(this)
-	return table_writeBytes(this.buffer)
+	return table_writeBytes(this.stack)
 end
 
 --[[@
 	@name new
 	@desc Creates a new instance of a Byte Array. Alias: `byteArray()`.
-	@param buffer?<table> An array of bytes.
-	@param pos?<int> A pointer to the current position in the buffer when reading.
+	@param stack?<table> An array of bytes.
 	@returns byteArray The new Byte Array object.
 	@struct {
-		buffer = { } -- The bytes buffer
+		stack = { } -- The bytes stack
 	}
 ]]
-byteArray.new = function(self, buffer)
+byteArray.new = function(self, stack)
 	return setmetatable({
-		pos = 1,
-		buffer = (buffer or { }) -- Array of bytes
+		stack = (stack or { }) -- Array of bytes
 	}, self)
 end
 --[[@
@@ -53,7 +51,7 @@ byteArray.write8 = function(self, ...)
 	end
 
 	local bytes = table_mapArray(tbl, modulo256)
-	table_add(self.buffer, bytes)
+	table_add(self.stack, bytes)
 	return self
 end
 --[[@
@@ -110,7 +108,7 @@ byteArray.writeUTF = function(self, utf)
 	end
 
 	self:write16(#utf)
-	table_add(self.buffer, utf)
+	table_add(self.stack, utf)
 
 	return self
 end
@@ -126,7 +124,7 @@ byteArray.writeBigUTF = function(self, bigUtf)
 	end
 
 	self:write24(#bigUtf)
-	table_add(self.buffer, bigUtf)
+	table_add(self.stack, bigUtf)
 
 	return self
 end
@@ -141,71 +139,71 @@ byteArray.writeBool = function(self, bool)
 end
 --[[@
 	@name read8
-	@desc Extracts bytes from the packet buffer. If there are not suficient bytes in the buffer, it's filled with bytes with value 0.
+	@desc Extracts bytes from the packet stack. If there are not suficient bytes in the stack, it's filled with bytes with value 0.
 	@param quantity<int> The quantity of bytes to be extracted. @default 1
 	@returns table,int A table with the extracted bytes. If there's only one byte, it is sent instead of the table.
 ]]
 byteArray.read8 = function(self, quantity)
 	quantity = quantity or 1
 
-	local byteBuffer = table_arrayRange(self.buffer, self.pos, self.pos + quantity)
-	self.pos = self.pos + quantity
+	local byteStack = table_arrayRange(self.stack, 1, quantity)
+	self.stack = table_arrayRange(self.stack, quantity + 1)
 
-	local sLen = #byteBuffer
+	local sLen = #byteStack
 	local fillVal = quantity - sLen
 	if fillVal > 0 then
 		for i = 1, fillVal do
-			byteBuffer[sLen + i] = 0
+			byteStack[sLen + i] = 0
 		end
 	end
 
-	return (quantity == 1 and byteBuffer[1] or byteBuffer)
+	return (quantity == 1 and byteStack[1] or byteStack)
 end
 --[[@
 	@name read16
-	@desc Extracts a short integer from the packet buffer.
+	@desc Extracts a short integer from the packet stack.
 	@returns int A short integer.
 ]]
 byteArray.read16 = function(self)
-	local shortBuffer = self:read8(2)
+	local shortStack = self:read8(2)
 	-- s[1] << 8 + s[2]
-	return bit_lshift(shortBuffer[1], 8) + shortBuffer[2]
+	return bit_lshift(shortStack[1], 8) + shortStack[2]
 end
 --[[@
 	@name readSigned16
-	@desc Extracts a short signed integer from the packet buffer.
+	@desc Extracts a short signed integer from the packet stack.
 	@returns int A short signed integer.
 ]]
 byteArray.readSigned16 = function(self)
-	local shortBuffer = self:read8(2)
+	local shortStack = self:read8(2)
 	-- ((s[1] << 8 | s[2] << 0) ~ 0x8000) - 0x8000
-	return bit_bxor(bit_bor(bit_lshift(shortBuffer[1], 8), bit_lshift(shortBuffer[2], 0)), 0x8000)
+	return bit_bxor(bit_bor(bit_lshift(shortStack[1], 8), bit_lshift(shortStack[2], 0)), 0x8000)
 		- 0x8000
 end
 --[[@
 	@name read24
-	@desc Extracts an integer from the packet buffer.
+	@desc Extracts an integer from the packet stack.
 	@returns int An integer.
 ]]
 byteArray.read24 = function(self)
-	local intBuffer = self:read8(3)
+	local intStack = self:read8(3)
 	-- i[1] << 16 + i[2] << 8 + i[3]
-	return bit_lshift(intBuffer[1], 16) + bit_lshift(intBuffer[2], 8) + intBuffer[3]
+	return bit_lshift(intStack[1], 16) + bit_lshift(intStack[2], 8) + intStack[3]
 end
 --[[@
 	@name read32
-	@desc Extracts a long integer from the packet buffer.
+	@desc Extracts a long integer from the packet stack.
 	@returns int A long integer.
 ]]
 byteArray.read32 = function(self)
-	local longBuffer = self:read8(4)
+	local longStack = self:read8(4)
 	-- l[1] << 24 + l[2] << 16 + l[3] << 8 + l[4]
-	return bit_lshift(longBuffer[1], 24) + bit_lshift(longBuffer[2], 16) + bit_lshift(longBuffer[3], 8)
-		+ longBuffer[4]
+	return bit_lshift(longStack[1], 24) + bit_lshift(longStack[2], 16) + bit_lshift(longStack[3], 8)
+		+ longStack[4]
 end
 --[[@
 	@name readUTF
-	@desc Extracts a string from the packet buffer.
+	@desc Extracts a string from the packet stack.
 	@returns string A string.
 ]]
 byteArray.readUTF = function(self)
@@ -218,7 +216,7 @@ byteArray.readUTF = function(self)
 end
 --[[@
 	@name readBigUTF
-	@desc Extracts a long string from the packet buffer.
+	@desc Extracts a long string from the packet stack.
 	@returns string A long string.
 ]]
 byteArray.readBigUTF = function(self)
@@ -231,7 +229,7 @@ byteArray.readBigUTF = function(self)
 end
 --[[@
 	@name readBool
-	@desc Extracts a boolean from the packet buffer. (Whether the next byte is 0 or 1)
+	@desc Extracts a boolean from the packet stack. (Whether the next byte is 0 or 1)
 	@returns boolean A boolean.
 ]]
 byteArray.readBool = function(self)

--- a/libs/bArray.lua
+++ b/libs/bArray.lua
@@ -14,7 +14,7 @@ local table_writeBytes = table.writeBytes
 ------------------
 
 local band255 = function(n)
-	return bit_band(n, 255)
+	return bit_band(n, 0xFF)
 end
 
 ------------------

--- a/libs/bArray.lua
+++ b/libs/bArray.lua
@@ -28,6 +28,7 @@ end
 	@name new
 	@desc Creates a new instance of a Byte Array. Alias: `byteArray()`.
 	@param stack?<table> An array of bytes.
+	@param pos?<int> A pointer to the current position in the stack when reading.
 	@returns byteArray The new Byte Array object.
 	@struct {
 		stack = { } -- The bytes stack
@@ -35,6 +36,7 @@ end
 ]]
 byteArray.new = function(self, stack)
 	return setmetatable({
+		pos = 1,
 		stack = (stack or { }) -- Array of bytes
 	}, self)
 end
@@ -146,8 +148,8 @@ end
 byteArray.read8 = function(self, quantity)
 	quantity = quantity or 1
 
-	local byteStack = table_arrayRange(self.stack, 1, quantity)
-	self.stack = table_arrayRange(self.stack, quantity + 1)
+	local byteStack = table_arrayRange(self.stack, self.pos, self.pos + quantity)
+	self.pos = self.pos + quantity
 
 	local sLen = #byteStack
 	local fillVal = quantity - sLen

--- a/libs/client.lua
+++ b/libs/client.lua
@@ -1045,7 +1045,7 @@ packetListener = {
 
 			local roomType, community, name, count, max, onFcMode
 			local roomMode = packet:read8()
-			while #packet.stack > 0 do
+			while packet:bytesLeft() > 0 do
 				roomType = packet:read8()
 				if roomType == 0 then -- Normal room
 					community = packet:read8()
@@ -1139,7 +1139,7 @@ packetListener = {
 			local id, data
 			local _messages, _totalMessages, _author
 
-			while #packet.stack > 0 do
+			while packet:bytesLeft() > 0 do
 				id = packet:read32()
 				data = { id = id }
 				data.title = packet:readUTF()

--- a/libs/encode.lua
+++ b/libs/encode.lua
@@ -139,7 +139,7 @@ end
 	@returns byteArray The encoded Byte Array object.
 ]]
 local btea = function(packet)
-	local stackLen = #packet.stack
+	local stackLen = packet:bytesLeft()
 
 	if stackLen == 0 then
 		return error("↑failure↓[ENCODE]↑ BTEA algorithm can't be applied to an empty byteArray.",
@@ -153,7 +153,7 @@ local btea = function(packet)
 	packet = byteArray:new(packet.stack) -- Saves resource, instead of using write8
 
 	local chunks, counter = { }, 0
-	while #packet.stack > 0 do
+	while packet:bytesLeft() > 0 do
 		counter = counter + 1
 		chunks[counter] = packet:read32()
 	end
@@ -178,7 +178,7 @@ end
 local xorCipher = function(packet, fingerprint)
 	local stack = { }
 
-	for i = 1, #packet.stack do
+	for i = 1, packet:bytesLeft() do
 		fingerprint = fingerprint + 1
 		stack[i] = bit_band(bit_bxor(packet.stack[i], messageKeys[(fingerprint % 20) + 1]), 0xFF)
 	end

--- a/libs/encode.lua
+++ b/libs/encode.lua
@@ -139,7 +139,7 @@ end
 	@returns byteArray The encoded Byte Array object.
 ]]
 local btea = function(packet)
-	local stackLen = packet:bytesLeft()
+	local stackLen = #packet.stack
 
 	if stackLen == 0 then
 		return error("↑failure↓[ENCODE]↑ BTEA algorithm can't be applied to an empty byteArray.",
@@ -150,7 +150,6 @@ local btea = function(packet)
 		stackLen = stackLen + 1
 		packet.stack[stackLen] = 0
 	end
-	packet = byteArray:new(packet.stack) -- Saves resource, instead of using write8
 
 	local chunks, counter = { }, 0
 	while packet:bytesLeft() > 0 do
@@ -160,6 +159,7 @@ local btea = function(packet)
 
 	chunks = xxtea(chunks)
 
+	packet.stack = {}
 	packet:write16(#chunks)
 	for i = 1, #chunks do
 		packet:write32(chunks[i])
@@ -178,7 +178,7 @@ end
 local xorCipher = function(packet, fingerprint)
 	local stack = { }
 
-	for i = 1, packet:bytesLeft() do
+	for i = 1, #packet.stack do
 		fingerprint = fingerprint + 1
 		stack[i] = bit_band(bit_bxor(packet.stack[i], messageKeys[(fingerprint % 20) + 1]), 0xFF)
 	end


### PR DESCRIPTION
Uses a buffer with a position pointer instead of a stack.
Doesn't consume the buffer when reading. It makes the code much faster. The stack were reallocating and copying the whole data each time you were reading something.